### PR TITLE
Fix serde time deserialization

### DIFF
--- a/crates/importer/src/main.rs
+++ b/crates/importer/src/main.rs
@@ -1,7 +1,7 @@
 use anyhow::{Context, Result};
 use clap::Parser;
 use rusqlite::{params, Connection};
-use serde::{Deserialize, Deserializer};
+use serde::Deserialize;
 use serde_json::Value;
 use std::collections::HashMap;
 use std::fs;
@@ -64,7 +64,7 @@ struct MappingNode {
 struct Message {
     id: String,
     author: Author,
-    #[serde(with = "flexible_time")]
+    #[serde(deserialize_with = "flexible_time::deserialize")]
     create_time: Option<f64>,
     update_time: Option<f64>,
     content: Content,


### PR DESCRIPTION
## Summary
- fix incorrect serde attribute for `Message::create_time`
- remove unused Deserializer import

## Testing
- `cargo fmt --all -- --check` *(fails: rustfmt not installed)*
- `cargo test` *(fails: could not fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_68446e5f05a08330ae8a3afad46642a4